### PR TITLE
Replace <style> for compliance with CSP header

### DIFF
--- a/ext_icon.svg
+++ b/ext_icon.svg
@@ -1,39 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-	xmlns:dc="http://purl.org/dc/elements/1.1/"	
-	xmlns:cc="http://creativecommons.org/ns#"
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-	xmlns:svg="http://www.w3.org/2000/svg"
-	xmlns="http://www.w3.org/2000/svg"
+<svg xmlns="http://www.w3.org/2000/svg"
 	height="256px"
 	width="256px"
 	viewBox="0 0 256 256"
 	id="svg4148"
 	version="1.1">
-	<metadata
-		id="metadata4162">
-		<rdf:RDF>
-			<cc:Work
-				rdf:about="">
-				<dc:format>image/svg+xml</dc:format>
-				<dc:type
-					rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-				<dc:title>translate_locallang</dc:title>
-				<cc:license
-					rdf:resource="" />
-			</cc:Work>
-		</rdf:RDF>
-	</metadata>
-	<defs
-		id="defs4160" />
-	<title
-		id="title4150">translate_locallang</title>
-	<path
-		style="fill:#558b87;fill-opacity:1;fill-rule:evenodd"
-		id="path4154"
+	<title>translate_locallang</title>
+	<path fill="#558b87" fill-opacity="1" fill-rule="evenodd"
 		d="m 0,0 256,0 0,256 -256,0 z" />
-	<path
-		d="m 96.390104,188.3999 13.949036,-3.81274 q 1.95287,-0.55796 3.06879,-1.95287 1.11592,-1.3949 1.11592,-3.44076 l 0,-102.757918 -27.154126,0 q -1.859872,0 -2.696812,0.929936 -0.836944,0.929936 -1.301912,2.32484 l -7.2535,20.551582 -7.2535,0 0,-34.96559 118.84581,0 0,34.96559 -7.2535,0 -7.2535,-20.551582 q -0.46497,-1.394904 -1.30191,-2.32484 -0.83694,-0.929936 -2.51083,-0.929936 l -27.61909,0 0,102.757918 q 0,2.13885 1.3019,3.53376 1.30192,1.3949 2.9758,1.85987 l 13.94904,3.81274 0,5.95159 -63.607616,0 0,-5.95159 z"
-		style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;"
-		id="path4727" />
+	<path fill="#ffffff" fill-opacity="1" fill-rule="evenodd"
+		d="m 96.390104,188.3999 13.949036,-3.81274 q 1.95287,-0.55796 3.06879,-1.95287 1.11592,-1.3949 1.11592,-3.44076 l 0,-102.757918 -27.154126,0 q -1.859872,0 -2.696812,0.929936 -0.836944,0.929936 -1.301912,2.32484 l -7.2535,20.551582 -7.2535,0 0,-34.96559 118.84581,0 0,34.96559 -7.2535,0 -7.2535,-20.551582 q -0.46497,-1.394904 -1.30191,-2.32484 -0.83694,-0.929936 -2.51083,-0.929936 l -27.61909,0 0,102.757918 q 0,2.13885 1.3019,3.53376 1.30192,1.3949 2.9758,1.85987 l 13.94904,3.81274 0,5.95159 -63.607616,0 0,-5.95159 z" />
 </svg>


### PR DESCRIPTION
SVG is not loaded when the Content-Security-Policy header contains the widely used setting "style-src 'self';" because then the browser must rejects to load external files containing styles. In this case a black rectangle is displayed.
Using attributes instead of styles is compliant with CSP "style-src 'self';" and the file will be loaded.