### PR TITLE
Move to xliff version 1.2

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" target-language="de" datatype="plaintext" original="EXT:translate_locallang/Resources/Private/Language/locallang.xlf" date="2021-01-11T17:43:59Z" product-name="translate_locallang">
 		<header/>
 		<body>

--- a/Resources/Private/Language/de.locallang_mod.xlf
+++ b/Resources/Private/Language/de.locallang_mod.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" target-language="de" datatype="plaintext" original="EXT:translate_locallang/Resources/Private/Language/locallang_mod.xlf" date="2021-01-11T17:43:55Z" product-name="translate_locallang">
 		<header/>
 		<body>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" datatype="plaintext" original="EXT:translate_locallang/Resources/Private/Language/locallang.xlf" date="2021-01-11T17:43:59Z" product-name="translate_locallang">
 		<header/>
 		<body>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" datatype="plaintext" original="EXT:translate_locallang/Resources/Private/Language/locallang_mod.xlf" date="2021-01-11T17:43:55Z" product-name="translate_locallang">
 		<header/>
 		<body>

--- a/Resources/Private/Templates/Empty.xlf
+++ b/Resources/Private/Templates/Empty.xlf
@@ -4,7 +4,7 @@
 		<header/>
 		<body>
 			<trans-unit id="new" resname="new">
-				<source/>
+				<source></source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Templates/Empty.xlf
+++ b/Resources/Private/Templates/Empty.xlf
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="en" datatype="plaintext" original="" date="" product-name="">
 		<header/>
 		<body>

--- a/Resources/Private/Templates/Empty.xlf
+++ b/Resources/Private/Templates/Empty.xlf
@@ -4,7 +4,7 @@
 		<header/>
 		<body>
 			<trans-unit id="new" resname="new">
-				<source></source>
+				<source/>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Templates/Xliff.html
+++ b/Resources/Private/Templates/Xliff.html
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
 	<file source-language="{sourcelang}"{f:if(condition:'{targetlang}',then:' target-language="{targetlang}"')} datatype="plaintext" original="{original}" date="{date}" product-name="{productname}">
 		<header/>
 		<body><f:for each="{labels}" as="label" key="key">


### PR DESCRIPTION
```
# https://github.com/TYPO3-Documentation/tea/blob/main/.github/workflows/ci.yml#L87-L95

$ wget -nv https://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd
2021-02-17 15:43:01 URL:https://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd [105649/105649] -> "xliff-core-1.2-strict.xsd" [1]
$ xmllint --schema xliff-core-1.2-strict.xsd  --noout ./Resources/Private/Language/locallang.xlf
./Resources/Private/Language/locallang.xlf validates
```