### PR TITLE
Protect default language when useL10n=2

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -36,6 +36,10 @@ use Undefined\TranslateLocallang\Utility\TranslateUtility;
 
 class ModuleController extends ActionController
 {
+    const MODE_DEFAULT       = 0;
+    const MODE_USE_L10N      = 1;
+    const MODE_USE_L10N_ONLY = 2;
+
     /**
      * @var array
      */
@@ -63,13 +67,14 @@ class ModuleController extends ActionController
         $this->conf['extFilter'] = trim((string)$extConf['extFilter']);
         $patterns = GeneralUtility::trimExplode(',', $this->conf['extFilter'], TRUE);
         $this->conf['extensions'] = TranslateUtility::getExtList($allowedExts, $this->conf['allowedFiles'], $patterns);
-        $this->conf['modifyKeys'] = (bool)$extConf['modifyKeys'] || $GLOBALS['BE_USER']->isAdmin();
+        $this->conf['modifyKeys'] = ((bool)$extConf['modifyKeys'] || $GLOBALS['BE_USER']->isAdmin()) && $extConf['useL10n'] != self::MODE_USE_L10N_ONLY;
+        $this->conf['uploadCsv'] = $this->conf['modifyKeys'] || $extConf['useL10n'] == self::MODE_USE_L10N_ONLY;
         $this->conf['useL10n'] = (bool)$extConf['useL10n'];
         $this->conf['clearCache'] = (bool)$extConf['clearCache'];
         $this->conf['langKeysAllowed'] = $this->conf['langKeys'];
         $this->conf['translatorInfo'] = (string)$extConf['translatorInfo'];
         if (!((bool)$extConf['modifyDefaultLang'] || $GLOBALS['BE_USER']->isAdmin() || $this->conf['modifyKeys']) ||
-            (bool)$this->conf['useL10n']) {
+            $extConf['useL10n'] == self::MODE_USE_L10N_ONLY) {
             unset($this->conf['langKeysAllowed']['default']);
         }
     }

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -68,7 +68,8 @@ class ModuleController extends ActionController
         $this->conf['clearCache'] = (bool)$extConf['clearCache'];
         $this->conf['langKeysAllowed'] = $this->conf['langKeys'];
         $this->conf['translatorInfo'] = (string)$extConf['translatorInfo'];
-        if (!((bool)$extConf['modifyDefaultLang'] || $GLOBALS['BE_USER']->isAdmin() || $this->conf['modifyKeys'])) {
+        if (!((bool)$extConf['modifyDefaultLang'] || $GLOBALS['BE_USER']->isAdmin() || $this->conf['modifyKeys']) ||
+            (bool)$this->conf['useL10n']) {
             unset($this->conf['langKeysAllowed']['default']);
         }
     }

--- a/Resources/Private/Partials/Module/List.html
+++ b/Resources/Private/Partials/Module/List.html
@@ -66,5 +66,16 @@
 	</f:if>
 	<br>
 	<br>
+	<f:if condition="{conf.uploadCsv}">
+		<div class="form-group">
+			<label>{f:translate(key: 'load_labels_from_csv_file')}</label>
+			<div class="input-group">
+				<f:form.upload name="importFile" class="form-control" style="display:inline-block;" />
+				<span class="input-group-btn">
+					<f:form.button formaction="{f:uri.action(action:'importCsv')}" value="{f:translate(key:'import')}" class="btn btn-default">{f:translate(key:'import')}</f:form.button>
+				</span>
+			</div>
+		</div>
+	</f:if>
 </f:form>
 </html>

--- a/Resources/Private/Partials/Module/List.html
+++ b/Resources/Private/Partials/Module/List.html
@@ -66,16 +66,5 @@
 	</f:if>
 	<br>
 	<br>
-	<f:if condition="{conf.uploadCsv}">
-		<div class="form-group">
-			<label>{f:translate(key: 'load_labels_from_csv_file')}</label>
-			<div class="input-group">
-				<f:form.upload name="importFile" class="form-control" style="display:inline-block;" />
-				<span class="input-group-btn">
-					<f:form.button formaction="{f:uri.action(action:'importCsv')}" value="{f:translate(key:'import')}" class="btn btn-default">{f:translate(key:'import')}</f:form.button>
-				</span>
-			</div>
-		</div>
-	</f:if>
 </f:form>
 </html>

--- a/Resources/Private/Templates/Module/List.html
+++ b/Resources/Private/Templates/Module/List.html
@@ -30,7 +30,7 @@
 					<f:form.hidden name="langKeys[{iter.index}]" value="{langKey}" />
 				</f:for>
 			</f:form>
-			<f:if condition="{conf.modifyKeys}">
+			<f:if condition="{conf.uploadCsv}">
 				<f:form id="translate_import" action="importCsv" controller="Module" class="form-group" enctype="multipart/form-data">
 					<f:form.hidden name="extension" value="{extension}" />
 					<f:form.hidden name="file" value="{file}" />

--- a/Resources/Public/Css/translate.css
+++ b/Resources/Public/Css/translate.css
@@ -53,6 +53,9 @@
 	overflow-y:auto;
 	padding:0;
 }
+.translate-row textarea[readonly] {
+	color: gray;
+}
 .translate-row svg {
 	pointer-events:none;
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,7 +2,7 @@
 defaultLangKey = en
 # cat=basic//2; type=string; label=Translation language keys
 langKeys = de,fr,it
-# cat=basic//3; type=boolean; label=Save translations to 'labels' or 'l10n' folder instead of 'typo3conf/ext/'
+# cat=basic//3; type=options[No=0, Yes=1, Yes (strict)=2]; label=Save translations to 'labels' or 'l10n' folder instead of 'typo3conf/ext/'
 useL10n = 0
 # cat=basic//4; type=boolean; label=Clear l10n cache on save
 clearCache = 0


### PR DESCRIPTION
This patch changes the `useL10n` setting from boolean to dropdown and adds a 3rd option:
* 0 => No
* 1 => Yes
* 2 => Yes (strict)

When choosing "Yes (strict)" the extension behaves as before when setting the checkbox except for two things:
* Column with default language is readonly
* Buttons to the right of the table are missing (CSV-Upload is still possible though)

Obviously the language `en` needs now to be set to the list of `langKeys` in the extension settings to be able to provide english translations now.

Resolves: #45 