### PR TITLE
[TASK] Improve styles of translation table

### DIFF
--- a/Resources/Public/Css/translate.css
+++ b/Resources/Public/Css/translate.css
@@ -1,77 +1,94 @@
 .translate-table {
-	display:table;
-	position:relative;
-	width:100%;
-	border-collapse:collapse;
+	display: grid;
+	gap: 1px;
+	border: 1px solid #bbb;
+	background-color: #bbb;
+	min-width: min-content;
 }
+
 .translate-row {
-	display:table-row;
-	border:1px solid #aaaaaa;
+	display: flex;
+	gap: 1px;
+	background-color: #bbb;
 }
+
 .translate-row.over {
 	border-top: 2px solid #558b87;
 }
-.translate-row:hover {
-	background-color:#f2f2f2;
+
+.translate-row:hover > div:not(.same, .nd, .nt) {
+	background-color: #f2f2f2;
 }
+
 .translate-row.header {
-	border:1px solid #aaaaaa;
-	font-weight:bold;
+	font-weight: bold;
 }
+
 .translate-row.header > div {
 	padding: 4px;
 }
+
 .translate-row > div {
-	display:table-cell;
-	border-left:1px solid #aaaaaa;
-	border-right:1px solid #aaaaaa;
-	vertical-align:top;
-	line-height:normal;
+	width: 100%;
+	background-color: #fff;
+	line-height: normal;
 }
+
 .translate-row > div:focus-within {
-	outline: 2px solid #aaaaaa;
+	outline: 2px solid #558b87;
 	outline-offset: -2px;
 }
+
 .translate-row > .same {
-	background-color:#dbeceb;
+	background-color: #dbeceb;
 }
+
 .translate-row > .nd {
-	background-color:#e5bcbc;
+	background-color: #e5bcbc;
 }
+
 .translate-row > .nt {
-	background-color:#ffe3e3;
+	background-color: #ffe3e3;
 }
+
 .translate-row input {
-	width:100%;
-	border:none;
-	outline:none;
-	background-color:transparent;
-	line-height:normal;
-	padding:4px;
+	width: 100%;
+	min-width: 150px;
+	padding: 4px;
+	border: none;
+	background-color: transparent;
+	outline: none;
+	line-height: normal;
 }
+
 .translate-row textarea {
+	overflow-y: auto;
+	width: 100%;
+	min-width: 150px;
+	height: 3.2em;
+	padding: 4px;
+	border: none;
+	background-color: transparent;
+	outline: none;
+	line-height: normal;
 	resize: none;
-	width:100%;
-	border:none;
-	outline:none;
-	background-color:transparent;
-	line-height:normal;
-	height:2.9em;
-	overflow-y:auto;
-	padding:4px;
 }
+
 .translate-row svg {
-	pointer-events:none;
+	pointer-events: none;
 }
+
 .translate-row > .add, .translate-row > .del, .translate-row > .move {
-	width:2em;
-	padding:4px;
+	width: 3.6em;
+	min-width: 3.6em;
+	padding: 4px;
 }
 
 form.form-group select {
 	width: 100%;
 	margin-bottom: 8px;
 }
+
 form.form-group select.form-control[multiple] {
 	min-height: 0;
 }


### PR DESCRIPTION
* Prevents scrollbar for textareas equal or less than two lines
* Focus style follows extension colors
* Rebuild css-table layout to grid and flex to prevent border collapsing with focus-styles

Resolves: #63

@rrrapha I have polished the last styles a little bit to prevent inconsistent borders and focus styles that sometimes collapse on lower or special scaled resolutions. I got positive feedback from the last project where we worked with these adjustments.