### PR TITLE
Update TranslateUtility.php

### DIFF
--- a/Classes/Utility/TranslateUtility.php
+++ b/Classes/Utility/TranslateUtility.php
@@ -82,7 +82,7 @@ class TranslateUtility
         $files = [];
         $langdir = $extension['packagePath'] . static::LANGUAGE_DIR;
 
-        $allfiles = GeneralUtility::getAllFilesAndFoldersInPath([], $langdir . '/', 'xlf', false, 3);
+        $allfiles = GeneralUtility::getAllFilesAndFoldersInPath([], $langdir . '/', 'xlf', false, 5);
         foreach($allfiles as $file) {
                 $filename = str_replace($langdir . '/', '', $file);
                 $parts = explode('.', $filename);


### PR DESCRIPTION
Allow the folder depth of 5 to be able to use the standard structure: Resources/Private/Language/Overrides/AnotherExt/Resources/Private/Language/

This could be used to fix this: https://github.com/rrrapha/translate_locallang/issues/75