### PR TITLE
[BUGFIX] Consider new universal tag attribute behaviour of `readonly`

### DIFF
--- a/Resources/Private/Partials/Module/List.html
+++ b/Resources/Private/Partials/Module/List.html
@@ -24,10 +24,24 @@
 		<f:if condition="{key}">
 		<div class="translate-row">
 			<div>
-				<f:form.textfield name="keys[{key}]" value="{key}" readonly="{f:if(condition:'{conf.modifyKeys}',else:'1')}" />
+                <f:if condition="{conf.modifyKeys}">
+                    <f:then>
+                        <f:form.textfield name="keys[{key}]" value="{key}" />
+                    </f:then>
+                    <f:else>
+                        <f:form.textfield name="keys[{key}]" value="{key}" readonly />
+                    </f:else>
+                </f:if>
 			</div>
 			<div class="{f:if(condition:'{label.default}',else:'nd')}">
-				<f:form.textarea name="labels[{key}][default]" value="{label.default}" readonly="{f:if(condition:'{conf.langKeysAllowed.default}',else:'1')}" />
+                <f:if condition="{conf.langKeysAllowed.default}">
+                    <f:then>
+                        <f:form.textarea name="labels[{key}][default]" value="{label.default}" />
+                    </f:then>
+                    <f:else>
+                        <f:form.textarea name="labels[{key}][default]" value="{label.default}" readonly />
+                    </f:else>
+                </f:if>
 			</div>
 			<f:for each="{label}" as="value" key="langKey">
 				<f:if condition="{langKey} != 'default'">
@@ -44,10 +58,24 @@
 		</f:for>
 		<div class="translate-row">
 			<div>
-				<f:form.textfield name="keys[_newkey{time}]" value="" readonly="{f:if(condition:'{conf.modifyKeys}',else:'1')}" />
+                <f:if condition="{conf.modifyKeys}">
+                    <f:then>
+                        <f:form.textfield name="keys[_newkey{time}]" value="" />
+                    </f:then>
+                    <f:else>
+                        <f:form.textfield name="keys[_newkey{time}]" value="" readonly />
+                    </f:else>
+                </f:if>
 			</div>
 			<div>
-				<f:form.textarea name="labels[_newkey{time}][default]" value="" readonly="{f:if(condition:'{conf.langKeysAllowed.default}',else:'1')}" />
+                <f:if condition="{conf.langKeysAllowed.default}">
+                    <f:then>
+                        <f:form.textarea name="labels[_newkey{time}][default]" value="" />
+                    </f:then>
+                    <f:else>
+                        <f:form.textarea name="labels[_newkey{time}][default]" value="" readonly />
+                    </f:else>
+                </f:if>
 			</div>
 			<f:for each="{langKeys}" as="langKey">
 			<f:if condition="{langKey} != 'default'">


### PR DESCRIPTION
The dedicated tag attribute `readonly` of the `f:form.textarea` ViewHelper was removed by commit https://github.com/TYPO3/typo3/commit/21d3f18b0ee8c7e2915f2ca3d054704ce06a4ec4 in favour of the new universal tag attributes, which allow to define any attributes that are to be output directly in HTML.

Due to the boolean property of the `readonly` attribute, this results in a difference in the output behaviour by Fluid. Previously, an empty value for `readonly=""` in ViewHelper ensured that the `readonly` attribute was not output in HTML, while `readonly="1"` in HTML ensured that the `readonly` attribute was used. Since the changeover in TYPO3 v13, both spellings (with or without a value) result in the `readonly` attribute being output in HTML.

This is now corrected by no longer considering the originally intended conditions for the usage of the `readonly` attribute inline but in the surrounding context.

Resolves: rrrapha/translate_locallang#81